### PR TITLE
Fix: php spark won't start

### DIFF
--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -3,7 +3,7 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
-use Kint\Renderer\Renderer;
+use Kint\Renderer\AbstractRenderer as Renderer;
 
 /**
  * --------------------------------------------------------------------------


### PR DESCRIPTION
because of Kint\Renderer\Renderer is not found